### PR TITLE
GHC-8.2 support

### DIFF
--- a/libui.cabal
+++ b/libui.cabal
@@ -91,6 +91,7 @@ library
       ./vendor/libui/unix/entry.c
       ./vendor/libui/unix/fontbutton.c
       ./vendor/libui/unix/form.c
+      ./vendor/libui/unix/future.c
       ./vendor/libui/unix/graphemes.c
       ./vendor/libui/unix/grid.c
       ./vendor/libui/unix/group.c

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,9 @@
 flags: {}
 extra-package-dbs: []
 packages:
-- '.'
+- .
 - location: ./vendor/haskell-ascii-progress
   extra-dep: true
 extra-deps:
 - c-storable-deriving-0.1.3
-- pqueue-1.3.1.1
-- reactive-banana-1.1.0.1
-resolver: lts-6.7
+resolver: lts-10.2


### PR DESCRIPTION
While building this library on linux, I got errors: `undefined reference to loadFutures` and `undefined reference to FUTURE_pango_attr_foreground_alpha_new`.
Adding `./vendor/libui/unix/future.c` to cabal file is to resolve this error.

Also, lts-10.x (based on ghc-8.2) was released and it will be mainly used in the future, I suggest bumping the lts version.
If you don't want to bump up, just ignore this PR. But at least you need to add `future.c` to get it to work.

Sorry for doing two things in one PR, this is such a small change. :grin: 